### PR TITLE
Pragma Fixed

### DIFF
--- a/BlockChain/Contracts/Common/common.sol
+++ b/BlockChain/Contracts/Common/common.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 enum State {
     Invalid,

--- a/BlockChain/Contracts/JetonsDefaultPool.sol
+++ b/BlockChain/Contracts/JetonsDefaultPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import "./Common/common.sol";
 

--- a/BlockChain/Contracts/JetonsPoolFactory.sol
+++ b/BlockChain/Contracts/JetonsPoolFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import "./Common/common.sol";
 import "./JetonsDefaultPool.sol";

--- a/BlockChain/Contracts/JetonsPoolsManager.sol
+++ b/BlockChain/Contracts/JetonsPoolsManager.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.15;
+pragma solidity 0.8.15;
 
 import "./Common/common.sol";
 import "./JetonsDefaultPool.sol";


### PR DESCRIPTION
Floating pragmas are considered a bad practice.

It is always recommended that `pragma` should be fixed (not floating) to the version that you are intending to deploy your contracts with.

For more information Check [this](https://www.oreilly.com/library/view/mastering-blockchain-programming/9781839218262/d1250994-b952-4d5e-9cde-1b852c18b55f.xhtml) out

Issue #13 Solved.
I hope that the team and community will appreciate my small contribution to this beautiful project :)

Thanks,
AB Dee.